### PR TITLE
Made the pathing a little more platform agnostic

### DIFF
--- a/pdf-markdown-ocr.ipynb
+++ b/pdf-markdown-ocr.ipynb
@@ -2,9 +2,34 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: mistralai in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (1.5.1)\n",
+      "Requirement already satisfied: eval-type-backport>=0.2.0 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from mistralai) (0.2.2)\n",
+      "Requirement already satisfied: httpx>=0.27.0 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from mistralai) (0.28.1)\n",
+      "Requirement already satisfied: jsonpath-python>=1.0.6 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from mistralai) (1.0.6)\n",
+      "Requirement already satisfied: pydantic>=2.9.0 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from mistralai) (2.10.6)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from mistralai) (2.9.0)\n",
+      "Requirement already satisfied: typing-inspect>=0.9.0 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from mistralai) (0.9.0)\n",
+      "Requirement already satisfied: anyio in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from httpx>=0.27.0->mistralai) (4.7.0)\n",
+      "Requirement already satisfied: certifi in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from httpx>=0.27.0->mistralai) (2024.7.4)\n",
+      "Requirement already satisfied: httpcore==1.* in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from httpx>=0.27.0->mistralai) (1.0.7)\n",
+      "Requirement already satisfied: idna in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from httpx>=0.27.0->mistralai) (3.7)\n",
+      "Requirement already satisfied: h11<0.15,>=0.13 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from httpcore==1.*->httpx>=0.27.0->mistralai) (0.14.0)\n",
+      "Requirement already satisfied: annotated-types>=0.6.0 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from pydantic>=2.9.0->mistralai) (0.7.0)\n",
+      "Requirement already satisfied: pydantic-core==2.27.2 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from pydantic>=2.9.0->mistralai) (2.27.2)\n",
+      "Requirement already satisfied: typing-extensions>=4.12.2 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from pydantic>=2.9.0->mistralai) (4.12.2)\n",
+      "Requirement already satisfied: six>=1.5 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from python-dateutil>=2.8.2->mistralai) (1.16.0)\n",
+      "Requirement already satisfied: mypy-extensions>=0.3.0 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from typing-inspect>=0.9.0->mistralai) (1.0.0)\n",
+      "Requirement already satisfied: sniffio>=1.1 in /Users/josephallyndree/miniconda3/envs/zotero/lib/python3.12/site-packages (from anyio->httpx>=0.27.0->mistralai) (1.3.1)\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install mistralai"
    ]
@@ -104,9 +129,9 @@
     "    print(f\"Processing {pdf_path.name} ...\")\n",
     "    \n",
     "    # Output folders\n",
-    "    output_dir = OUTPUT_ROOT_DIR / pdf_base\n",
+    "    output_dir = os.sep.join([OUTPUT_ROOT_DIR, pdf_base])\n",
     "    output_dir.mkdir(exist_ok=True)\n",
-    "    images_dir = output_dir / \"images\"\n",
+    "    images_dir = os.sep.join([output_dir,\"images\"])\n",
     "    images_dir.mkdir(exist_ok=True)\n",
     "    \n",
     "    # PDF -> OCR\n",
@@ -131,7 +156,7 @@
     "    \n",
     "    # Save OCR in JSON \n",
     "    # (in case something fails it could be reused, but it is not used in the rest of the code)\n",
-    "    ocr_json_path = output_dir / \"ocr_response.json\"\n",
+    "    ocr_json_path = os.sep.join([output_dir, \"ocr_response.json\"])\n",
     "    with open(ocr_json_path, \"w\", encoding=\"utf-8\") as json_file:\n",
     "        json.dump(ocr_response.dict(), json_file, indent=4, ensure_ascii=False)\n",
     "    print(f\"OCR response saved in {ocr_json_path}\")\n",
@@ -159,7 +184,7 @@
     "            global_counter += 1\n",
     "            \n",
     "            # save in subfolder\n",
-    "            image_output_path = images_dir / new_image_name\n",
+    "            image_output_path = os.sep.join([images_dir,new_image_name])\n",
     "            with open(image_output_path, \"wb\") as f:\n",
     "                f.write(image_bytes)\n",
     "            \n",
@@ -171,7 +196,7 @@
     "        updated_markdown_pages.append(updated_markdown)\n",
     "    \n",
     "    final_markdown = \"\\n\\n\".join(updated_markdown_pages)\n",
-    "    output_markdown_path = output_dir / \"output.md\"\n",
+    "    output_markdown_path = os.sep.join([output_dir,\"output.md\"])\n",
     "    with open(output_markdown_path, \"w\", encoding=\"utf-8\") as md_file:\n",
     "        md_file.write(final_markdown)\n",
     "    print(f\"Markdown generated in {output_markdown_path}\")"
@@ -195,7 +220,7 @@
     "for pdf_file in pdf_files:\n",
     "    try:\n",
     "        process_pdf(pdf_file)\n",
-    "        shutil.move(str(pdf_file), DONE_DIR / pdf_file.name)\n",
+    "        shutil.move(str(pdf_file), f\"{os.sep.join([DONE_DIR,pdf_file.name])}\")\n",
     "        print(f\"{pdf_file.name} moved to {DONE_DIR}\")\n",
     "    except Exception as e:\n",
     "        print(f\"Error processing {pdf_file.name}: {e}\")\n"
@@ -204,7 +229,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "zotero",
    "language": "python",
    "name": "python3"
   },
@@ -218,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Made the pathing a little more platform agnostic by replacing the "/" used only on windows system to the `os.sep.join` function that automatically replace the file separator by the separator of choice depending on the platform.

Thanks for the good work anyway !
Hope it can reach more people this way ;)
