### PR TITLE
Add configurable page separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ python app.py
 ```
 Then open your browser at `http://localhost:5000/`
 
+### Customizing Page Separators
+
+The app inserts `---` between PDF pages by default. Set the `PAGE_SEPARATOR` environment
+variable to change this text or leave it empty to merge pages without separators.
+The web interface also lets you toggle and edit the separator before processing.
+
 ## Option 3: Jupyter Notebook
 
 ### Installation

--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ UPLOAD_FOLDER = Path(os.getenv('UPLOAD_FOLDER', 'uploads'))
 OUTPUT_FOLDER = Path(os.getenv('OUTPUT_FOLDER', 'output'))
 app.config['MAX_CONTENT_LENGTH'] = 50 * 1024 * 1024
 ALLOWED_EXTENSIONS = {'pdf'}
+PAGE_SEPARATOR_DEFAULT = os.getenv('PAGE_SEPARATOR', '---')
 
 UPLOAD_FOLDER.mkdir(exist_ok=True)
 OUTPUT_FOLDER.mkdir(exist_ok=True)
@@ -50,9 +51,15 @@ def replace_images_in_markdown_with_wikilinks(markdown_str: str, image_mapping: 
 
 # --- Core Processing Logic ---
 
-def process_pdf(pdf_path: Path, api_key: str, session_output_dir: Path) -> tuple[str, str, list[str], Path, Path]:
+def process_pdf(pdf_path: Path, api_key: str, session_output_dir: Path, page_separator: str | None = PAGE_SEPARATOR_DEFAULT) -> tuple[str, str, list[str], Path, Path]:
     """
     Processes a single PDF file using Mistral OCR and saves results.
+
+    Args:
+        pdf_path: Path to the PDF file.
+        api_key: Mistral API key.
+        session_output_dir: Directory to store output.
+        page_separator: Text to insert between pages. Use empty string to join pages without a separator.
 
     Returns:
         A tuple (pdf_base_name, final_markdown_content, list_of_image_filenames, path_to_markdown_file, path_to_images_dir)
@@ -144,7 +151,8 @@ def process_pdf(pdf_path: Path, api_key: str, session_output_dir: Path) -> tuple
             updated_page_markdown = replace_images_in_markdown_with_wikilinks(current_page_markdown, page_image_mapping)
             updated_markdown_pages.append(updated_page_markdown)
 
-        final_markdown_content = "\n\n---\n\n".join(updated_markdown_pages) # Page separator
+        separator = f"\n\n{page_separator}\n\n" if page_separator else "\n\n"
+        final_markdown_content = separator.join(updated_markdown_pages)
         output_markdown_path = pdf_output_dir / f"{pdf_base_sanitized}_output.md"
 
         try:
@@ -203,7 +211,7 @@ def create_zip_archive(source_dir: Path, output_zip_path: Path):
 
 @app.route('/')
 def index():
-    return render_template('index.html')
+    return render_template('index.html', default_page_separator=PAGE_SEPARATOR_DEFAULT)
 
 @app.route('/check-api-key', methods=['GET'])
 def check_api_key():
@@ -255,6 +263,10 @@ def handle_process():
     processing_errors = []
     if invalid_files: processing_errors.append(f"Skipped non-PDF files: {', '.join(invalid_files)}")
 
+    page_separator = request.form.get('page_separator')
+    if page_separator is None:
+        page_separator = PAGE_SEPARATOR_DEFAULT
+
     for file in valid_files:
         original_filename = file.filename
         filename_sanitized = secure_filename(original_filename)
@@ -270,7 +282,7 @@ def handle_process():
 
             # Process PDF - Capture new return values
             processed_pdf_base, markdown_content, image_filenames, md_path, img_dir = process_pdf(
-                temp_pdf_path, api_key, session_output_dir
+                temp_pdf_path, api_key, session_output_dir, page_separator
             )
 
             # Create ZIP (using the individual output dir)

--- a/static/script.js
+++ b/static/script.js
@@ -2,10 +2,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('ocr-form');
     const apiKeyInput = document.getElementById('api-key');
     const fileInput = document.getElementById('pdf-files');
-    const apiKeyToggle = document.getElementById('api-key-toggle'); 
+    const apiKeyToggle = document.getElementById('api-key-toggle');
     const submitBtn = document.getElementById('submit-btn');
     const statusLog = document.getElementById('status-log');
     const loader = document.getElementById('loader');
+
+    // Page separator elements
+    const includeSeparatorCheckbox = document.getElementById('include-separator');
+    const separatorTextInput = document.getElementById('separator-text');
     
     // API Key elements
     const apiKeyGroup = document.getElementById('api-key-group');
@@ -46,6 +50,13 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Check API key on page load
     checkApiKey();
+
+    if (includeSeparatorCheckbox && separatorTextInput) {
+        separatorTextInput.disabled = !includeSeparatorCheckbox.checked;
+        includeSeparatorCheckbox.addEventListener('change', () => {
+            separatorTextInput.disabled = !includeSeparatorCheckbox.checked;
+        });
+    }
 
     function logStatus(message) {
         console.log(message);
@@ -194,6 +205,10 @@ document.addEventListener('DOMContentLoaded', () => {
         // Only append API key if user provided one (environment key will be used automatically)
         if (apiKey) {
             formData.append('api_key', apiKey);
+        }
+        if (includeSeparatorCheckbox) {
+            const sepValue = includeSeparatorCheckbox.checked ? separatorTextInput.value : '';
+            formData.append('page_separator', sepValue);
         }
         for (let i = 0; i < files.length; i++) {
             formData.append('pdf_files', files[i]);

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,6 +52,14 @@
             <small>Select one or more PDFs.</small>
             <small>Note: API rate limits may apply.</small>
           </div>
+          <div class="form-group">
+            <label>
+              <input type="checkbox" id="include-separator" {% if default_page_separator %}checked{% endif %}>
+              Insert page separators
+            </label>
+            <input type="text" id="separator-text" value="{{ default_page_separator }}" placeholder="---" style="width: 80px; margin-left: 10px;">
+            <small>Leave blank to merge pages without separators.</small>
+          </div>
           <button type="submit" id="submit-btn">Convert PDFs</button>
         </form>
       </section>


### PR DESCRIPTION
## Summary
- let PAGE_SEPARATOR env var control page breaks
- expose toggle in the web UI to edit/remove the separator
- send the setting to the backend when submitting
- mention the new option in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841b3f522a083259050666674a3c763